### PR TITLE
Use store id from config instead of using variable on store

### DIFF
--- a/mixins/StoreMixin.js
+++ b/mixins/StoreMixin.js
@@ -76,9 +76,16 @@ var StoreMixin = {
   store_addListeners: function () {
     Object.keys(this.store_listeners).forEach(function (storeID) {
       var listenerDetail = this.store_listeners[storeID];
+      var events = listenerDetail.events;
+      var eventKeys = Object.keys(events);
 
+      // Check that we actually have events to fire events on
+      if (!events || !eventKeys.length) {
+        throw new Error('No events found on listener configuration for store ' +
+          'with ID "' + storeID + '".');
+      }
       // Loop through all available events
-      Object.keys(listenerDetail.events).forEach(function (event) {
+      eventKeys.forEach(function (event) {
         var eventListenerID = event + LISTENER_SUFFIX;
 
         // Check to see if we are already listening for this event
@@ -93,7 +100,7 @@ var StoreMixin = {
 
         // Set up listener with store
         listenerDetail.store.addChangeListener(
-          listenerDetail.events[event], listenerDetail[eventListenerID]
+          events[event], listenerDetail[eventListenerID]
         );
       }.bind(this));
     }.bind(this));

--- a/mixins/StoreMixin.js
+++ b/mixins/StoreMixin.js
@@ -54,6 +54,8 @@ var StoreMixin = {
       }
     });
 
+    // TODO: this.store_listeners gets changed from an array to an object here.
+    // We shouldn't modify the structure
     this.store_listeners = storesListeners;
     this.store_addListeners();
   },

--- a/mixins/StoreMixin.js
+++ b/mixins/StoreMixin.js
@@ -146,10 +146,7 @@ var StoreMixin = {
     }
 
     // Call callback on component that implements mixin if it exists
-    var onChangeFn = this.store_getChangeFunctionName(
-      listenerDetail.storeID || listenerDetail.store.storeID,
-      event
-    );
+    var onChangeFn = this.store_getChangeFunctionName(storeID, event);
 
     if (this[onChangeFn]) {
       this[onChangeFn].apply(this, args);

--- a/mixins/StoreMixin.js
+++ b/mixins/StoreMixin.js
@@ -77,15 +77,14 @@ var StoreMixin = {
     Object.keys(this.store_listeners).forEach(function (storeID) {
       var listenerDetail = this.store_listeners[storeID];
       var events = listenerDetail.events;
-      var eventKeys = Object.keys(events);
 
       // Check that we actually have events to fire events on
-      if (!events || !eventKeys.length) {
+      if (typeof events !== 'object' || !Object.keys(events).length) {
         throw new Error('No events found on listener configuration for store ' +
           'with ID "' + storeID + '".');
       }
       // Loop through all available events
-      eventKeys.forEach(function (event) {
+      Object.keys(events).forEach(function (event) {
         var eventListenerID = event + LISTENER_SUFFIX;
 
         // Check to see if we are already listening for this event

--- a/mixins/StoreMixin.js
+++ b/mixins/StoreMixin.js
@@ -81,7 +81,8 @@ var StoreMixin = {
       var events = listenerDetail.events;
 
       // Check that we actually have events to fire events on
-      if (typeof events !== 'object' || !Object.keys(events).length) {
+      if (process.env.NODE_ENV !== 'production' &&
+        (typeof events !== 'object' || !Object.keys(events).length)) {
         throw new Error('No events found on listener configuration for store ' +
           'with ID "' + storeID + '".');
       }


### PR DESCRIPTION
This removes the need of having storeIDs on the stores them selves and can just rely on the configuration for the storeID.

We are already validating that the configuration added from the addStoreConfig has an storeID: https://github.com/dcos/dcos-ui/blob/master/src/js/plugin-bridge/PluginSDK.js#L198