### PR TITLE
Remove arbitrary timeout

### DIFF
--- a/utils/RequestUtil.js
+++ b/utils/RequestUtil.js
@@ -100,7 +100,6 @@ var RequestUtil = {
     options = Util.extend({}, {
       contentType: "application/json; charset=utf-8",
       type: "json",
-      timeout: 2000,
       method: "GET"
     }, options);
 


### PR DESCRIPTION
This is @orlandohohmeier's diff but I'm creating the PR.

Having a cluster on the other side of the world can lead to long request times which can cause the UI to be unusable with this timeout.