### PR TITLE
Warn whenever we force-update

### DIFF
--- a/mixins/StoreMixin.js
+++ b/mixins/StoreMixin.js
@@ -171,7 +171,7 @@ var StoreMixin = {
 
     // forceUpdate if not suppressed by configuration
     if (listenerDetail.suppressUpdate !== true && typeof this.forceUpdate === 'function') {
-      if (process.env.NODE_ENV !== 'production') {
+      if (process.env.NODE_ENV === 'performance') {
         var warning = 'Forced upates are an antipattern. ';
         if (this.saveState_key != null) {
           warning += 'Check the render method of ' + this.saveState_key + '.';

--- a/mixins/StoreMixin.js
+++ b/mixins/StoreMixin.js
@@ -171,6 +171,13 @@ var StoreMixin = {
 
     // forceUpdate if not suppressed by configuration
     if (listenerDetail.suppressUpdate !== true && typeof this.forceUpdate === 'function') {
+      if (process.env.NODE_ENV !== 'production') {
+        var warning = 'Forced upates are an antipattern. ';
+        if (this.saveState_key != null) {
+          warning += 'Check the render method of ' + this.saveState_key + '.';
+        }
+        console.warn(warning);
+      }
       this.forceUpdate();
     }
   },


### PR DESCRIPTION
> For I acknowledge my transgressions, and my sin is ever before me
-the psalmist

This PR is split from ~~#17~~, which should be merged before this one. We disagreed on whether it was appropriate for developers to see a helpful warning in the console when force-update was used, so it's split to this PR so as not to block the implementation. 

With this warning turned on, we will be reminded that there are performance issues we should address sooner rather than later. Without it, I'm afraid the neatness of the StoreMixin abstraction will insulate us from fixing our problems. 