### PR TITLE
Remove default timeout from RequestUtil

### DIFF
--- a/utils/RequestUtil.js
+++ b/utils/RequestUtil.js
@@ -5,6 +5,24 @@ var DEFAULT_ERROR_MESSAGE = "An error has occurred.";
 
 var activeRequests = {};
 
+function createRequestID(request) {
+  var contentType = request.contentType || '';
+  var data = '';
+  var headers = '';
+  var method = request.method || '';
+  var url = request.url || '';
+
+  if (request.data != null) {
+    data = JSON.stringify(request.data);
+  }
+
+  if (request.headers != null) {
+    headers = JSON.stringify(request.headers);
+  }
+
+  return method + ':' + url + ':' + data + ':' + contentType + ':' + headers;
+}
+
 function createCallbackWrapper(callback, requestID) {
   return function () {
     setRequestState(requestID, false);
@@ -73,7 +91,7 @@ var RequestUtil = {
   json: function (options) {
     // Default assign options to empty object
     options || (options = {});
-    var requestID = options.url;
+    var requestID = createRequestID(options);
 
     // The proxied success and error methods mark the request as inactive when
     // the request resolves.


### PR DESCRIPTION
This PR changes `RequestUtil#json` in the following ways...
- It will not send a request if a previous request to the same URL has not yet resolved
  - Before, it did this only if `hangingRequestCallback` was defined
- No timeout is applied by default
  - Before, it applied a 2 second timeout if `hangingRequestCallback` was not defined
- Constructs an ID for each request based on the request's `contentType`, `data`, `headers`, `method`, and `url`.

Previous functionality (some requests fail after 2 seconds):
![](https://cl.ly/2v2w2O2J3D0s/Screen%20Shot%202016-10-24%20at%204.03.33%20PM.png)

New functionality (requests wait indefinitely):
![](https://cl.ly/3U1T3q1A1M2V/Screen%20Shot%202016-10-24%20at%204.05.06%20PM.png)
